### PR TITLE
jc/fix_max_connections_bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ I started this project as a way to learn the basics of REST APIs and fullstack c
 3. Run setup entry point to configure .env and .db
     - `poetry run setup`
 4. Run unit tests to make sure everything runs correctly
-    - `poetry run pytest
+    - `poetry run pytest`
     - Note: I am still working out a `Max retries exceeded with url: ` error that shows up sometimes. If that happens move on to the next section.
 
 ## Running the flask server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def admin_access_app(request: pytest.FixtureRequest) -> Iterator[Union[Process, 
     _ = create_api(app)
     app_process = Process(target=app.run, kwargs={"debug": False})
     app_process.start()
+    time.sleep(0.5)
     yield app_process
     app_process.terminate()
     os.remove(test_db)
@@ -35,6 +36,7 @@ def base_access_app(request: pytest.FixtureRequest) -> Iterator[Union[Process, s
     _ = create_api(app)
     app_process = Process(target=app.run, kwargs={"debug": False})
     app_process.start()
+    time.sleep(0.5)
     yield app_process
     app_process.terminate()
     os.remove(test_db)


### PR DESCRIPTION
Fixes #12 

Adding a delay before yielding flask app processes should fix the issue of the socket not being set up before trying to test. This is a band-aid (as are all fixes that involve just delaying something).